### PR TITLE
fix files drop for filelisting with custom namespace syntax

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -392,9 +392,10 @@ jQuery(function () {
      * @return {string} The namespace referenced by the target or the current namespace
      */
     function getNamespaceFromTarget(target) {
-        if (jQuery(target).closest('.plugin__filelisting').length) {
+        var $filelisting = jQuery(target).closest('.plugin__filelisting');
+        if ($filelisting.length) {
             var $targetRow = jQuery(target).closest('tr');
-            return $targetRow.data('namespace') || $targetRow.data('childof') || window.JSINFO.namespace;
+            return $targetRow.data('namespace') || $targetRow.data('childof') || $filelisting.data('namespace') || window.JSINFO.namespace;
         }
         return window.JSINFO.namespace;
     }


### PR DESCRIPTION
The filelisting plugin's syntax: "{{filelisting>custom:namespace}}" let us display the files form other namespace than the current page namespace. This syntax wasn't respected by the dropfiles plugin which always uploaded the files to the current page namespace when the files was not dropped to the specific folder. This commit fixes that for the last version of dropfiles plugin: https://github.com/cosmocode/dokuwiki-plugin-filelisting/commit/9ae6cf1606491a66adbca982209d41e50b77e25e