### PR TITLE
minor js improvement - prevents js error for filelisting plugin

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -158,6 +158,11 @@ jQuery(function () {
     function onDragEnter(e) {
         cancelEvent(e);
 
+        // only for $editarea, not $filelisting
+        if (!$editarea.length) {
+            return;
+        }
+
         if ($editarea[0].selectionStart !== $lastKnownCaretPosition) {
             // IE 11 fix
             $editarea[0].setSelectionRange($lastKnownCaretPosition, $lastKnownCaretPosition);


### PR DESCRIPTION
This commit just fixes js error when the plugin is used together with the filelisting plugin. It doesn't modifiy the plugin's behaviour. 